### PR TITLE
support transparent tiles

### DIFF
--- a/tilemapbase/mapping.py
+++ b/tilemapbase/mapping.py
@@ -468,7 +468,7 @@ class Plotter():
         size = self._tile_provider.tilesize
         xs = size * (self.xtilemax + 1 - self.xtilemin)
         ys = size * (self.ytilemax + 1 - self.ytilemin)
-        out = _Image.new("RGB", (xs, ys))
+        out = _Image.new("RGBA", (xs, ys))
         for x in range(self.xtilemin, self.xtilemax + 1):
             for y in range(self.ytilemin, self.ytilemax + 1):
                 tile = self._tile_provider.get_tile(x, y, self.zoom)


### PR DESCRIPTION
I noticed tiles which have alpha channels in the original tiles from the server / in the cache get rendered without transparency. So if one wants to use overlay tiles, they cover what's plotted before (or it spoils anything else that relies on the transparency).

```
base_plotter = tilemapbase.Plotter(extent, some_Tiles_instance, width = 700)
overlay_plotter = tilemapbase.Plotter(extent, some_other_Tiles_instance, width = 700)
base_plotter.plot(ax)
overlay_plotter.plot(ax)
```

I fixed this by instantiating the merged tile image as `"RGBA"` instead of `"RGB"`. (I guess this could also be determined automatically from the downloaded image data…).