### PR TITLE
updating so OSM accepts headers

### DIFF
--- a/notebooks/Aspect ratios.ipynb
+++ b/notebooks/Aspect ratios.ipynb
@@ -72,7 +72,7 @@
     }
    ],
    "source": [
-    "t = tilemapbase.tiles.OSM\n",
+    "t = tilemapbase.tiles.build_OSM(headers={'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'})\n",
     "extent = tilemapbase.Extent.from_lonlat(\n",
     "                longitude_min=bbox.minx, \n",
     "                longitude_max=bbox.maxx,\n",

--- a/notebooks/Example.ipynb
+++ b/notebooks/Example.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "# Use open street map\n",
-    "t = tilemapbase.tiles.OSM"
+    "t = tilemapbase.tiles.build_OSM(headers={'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'})"
    ]
   },
   {

--- a/notebooks/Plotting over a basemap.ipynb
+++ b/notebooks/Plotting over a basemap.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "fig, ax = plt.subplots(figsize=(10,10))\n",
     "\n",
-    "plotter = tilemapbase.Plotter(extent, tilemapbase.tiles.OSM, width=600)\n",
+    "plotter = tilemapbase.Plotter(extent, tilemapbase.tiles.build_OSM(headers={'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'}), width=600)\n",
     "plotter.plot(ax)\n",
     "ax.plot(x, y, \"ro-\")"
    ]

--- a/notebooks/Projections.ipynb
+++ b/notebooks/Projections.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "import tilemapbase\n",
     "tilemapbase.start_logging()\n",
-    "tilemapbase.tiles.OSM.get_tile(0,0,0)"
+    "tilemapbase.tiles.build_OSM(headers={'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'}).get_tile(0,0,0)"
    ]
   },
   {

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+
 [![Build Status](https://travis-ci.org/MatthewDaws/TileMapBase.svg?branch=master)](https://travis-ci.org/MatthewDaws/TileMapBase) 
 
 # TileMapBase
@@ -36,6 +37,10 @@ or directly from GitHub:
 OpenStreetMap Data is "© OpenStreetMap contributors”, see http://www.openstreetmap.org/copyright
 
 Please remember that tile set usage is subject to constraints: https://operations.osmfoundation.org/policies/tiles/
+
+As of 25/05/2019  [OSM requires a user agent for all requests](https://operations.osmfoundation.org/policies/tiles/) for the examples, here we set a default of:
+
+    'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'
 
 ## Ordnance Survery data
 

--- a/tilemapbase/tiles.py
+++ b/tilemapbase/tiles.py
@@ -267,11 +267,18 @@ class Tiles():
         return self._cache
 
 
-"""Standard Open Street Map tile server."""
-OSM = Tiles("http://a.tile.openstreetmap.org/{zoom}/{x}/{y}.png", "OSM")
+"""We have to have functions for OSM realted requests so users can pass their own
+user agent strings
+"""
+def build_OSM(headers=None):
+    """Standard Open Street Map tile server."""
+    OSM = Tiles("http://a.tile.openstreetmap.org/{zoom}/{x}/{y}.png", "OSM", headers=headers)
+    return OSM
 
-"""Humanitarian Open Street Map tile server."""
-OSM_Humanitarian = Tiles("http://a.tile.openstreetmap.fr/hot/{zoom}/{x}/{y}.png ", "OSM_HUMANITARIAN")
+def build_OSM_Humanitarian(headers=None):
+    """Humanitarian Open Street Map tile server."""
+    OSM_Humanitarian = Tiles("http://a.tile.openstreetmap.fr/hot/{zoom}/{x}/{y}.png ", "OSM_HUMANITARIAN", headers=headers)
+    return OSM_Humanitarian
 
 """Stamen, Toner, Standard."""
 Stamen_Toner = Tiles("http://tile.stamen.com/toner/{zoom}/{x}/{y}.png", "STAMEN_TONER")


### PR DESCRIPTION
As of the weekend just gone, OSM now rejects nearly all requests that do not have a valid user agent supplied. The code as it was had no ability to pass a custom header when using the library as a third party plugin. I have put the OSM related requests into a function so that users can pass their own user agents.

I have included a working example user agent in the documentation as well, let me know what you think.