### PR TITLE
Prevent invalid cache

### DIFF
--- a/tests/test_ordnancesurvey.py
+++ b/tests/test_ordnancesurvey.py
@@ -50,7 +50,7 @@ def test_init():
 def test__separate_init():
     base = os.path.abspath(os.path.join("tests", "test_os_map_data", "data"))
     callback = mock.Mock()
-    ons._separate_init(re.compile("^[A-Za-z]{2}\d\d\.tif$"),
+    ons._separate_init(re.compile(r"^[A-Za-z]{2}\d\d\.tif$"),
         os.path.join("tests", "test_os_map_data"),
         callback)
     assert callback.call_args_list == [mock.call("BG76.tif", os.path.join(base, "one"))]

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -51,7 +51,7 @@ def test_Tiles(get, sqcache, image):
 
 @mock.patch("tilemapbase.tiles._sqcache")
 @mock.patch("requests.get")
-def test_invalid_Tiles(get, sqcache, image):
+def test_invalid_Tiles(get, sqcache):
     sqcache.get_from_cache.return_value = None
     get.return_value = Response(True, "abcdef")
 
@@ -63,9 +63,9 @@ def test_invalid_Tiles(get, sqcache, image):
 
 @mock.patch("tilemapbase.tiles._sqcache")
 @mock.patch("requests.get")
-def test_OSM(get, sqcache):
+def test_OSM(get, sqcache, image):
     sqcache.get_from_cache.return_value = None
-    get.return_value = Response(True, None)
+    get.return_value = Response(True, image)
 
     tiles.build_OSM().get_tile(5,10,20)
 

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -51,6 +51,18 @@ def test_Tiles(get, sqcache, image):
 
 @mock.patch("tilemapbase.tiles._sqcache")
 @mock.patch("requests.get")
+def test_invalid_Tiles(get, sqcache, image):
+    sqcache.get_from_cache.return_value = None
+    get.return_value = Response(True, "abcdef")
+
+    t = tiles.Tiles("example{zoom}/{x}/{y}.jpg", "TEST")
+    with pytest.raises(IOError) as exc_info:
+        x = t.get_tile(10,20,5)
+
+    assert "Received invalid tile" in str(exc_info.value)
+
+@mock.patch("tilemapbase.tiles._sqcache")
+@mock.patch("requests.get")
 def test_OSM(get, sqcache):
     sqcache.get_from_cache.return_value = None
     get.return_value = Response(True, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ def test_logging():
         logger.debug("Fish")
 
         call = stdmock.write.call_args_list[0]
-        assert call[0][0].endswith("DEBUG tilemapbase - Fish")
+        assert call[0][0].endswith("DEBUG tilemapbase - Fish\n")
 
 def test_Cache():
     c = utils.Cache()

--- a/tilemapbase/ordnancesurvey.py
+++ b/tilemapbase/ordnancesurvey.py
@@ -85,11 +85,11 @@ def init(start_directory):
 
 def _init_scan_one_directory(dir_name):
     global _lookup
-    oml = _re.compile("^[A-Z]{2}\d\d[NESW]{2}\.tif$")
-    vml = _re.compile("^[A-Z]{2}\d\d\.tif$")
-    tfk = _re.compile("^[A-Z]{2}\.tif$")
-    mini = _re.compile("^MiniScale.*\.tif$")
-    over = _re.compile("^GBOver.*\.tif$")
+    oml = _re.compile(r"^[A-Z]{2}\d\d[NESW]{2}\.tif$")
+    vml = _re.compile(r"^[A-Z]{2}\d\d\.tif$")
+    tfk = _re.compile(r"^[A-Z]{2}\.tif$")
+    mini = _re.compile(r"^MiniScale.*\.tif$")
+    over = _re.compile(r"^GBOver.*\.tif$")
     dirs = []
     dir_name = _os.path.abspath(dir_name)
     for entry in _os.scandir(dir_name):
@@ -469,7 +469,7 @@ class TwentyFiveRaster(TileSource):
     @staticmethod
     def init(start_directory):
         """Scan a directory for suitable tiles."""
-        matcher = _re.compile("^[a-z]{2}\d\d\.tif$")
+        matcher = _re.compile(r"^[a-z]{2}\d\d\.tif$")
         global _lookup
         _lookup[TwentyFiveRaster.name] = dict()
         def callback(filename, dir_name):
@@ -532,7 +532,7 @@ class MasterMap(TileSource):
     @staticmethod
     def init(start_directory):
         """Scan a directory for suitable tiles."""
-        matcher = _re.compile("^[A-Za-z]{2}\d{4}\.(tif|png)$")
+        matcher = _re.compile(r"^[A-Za-z]{2}\d{4}\.(tif|png)$")
         global _lookup
         _lookup[MasterMap.name] = dict()
         def callback(filename, dir_name):

--- a/tilemapbase/tiles.py
+++ b/tilemapbase/tiles.py
@@ -190,6 +190,11 @@ class _TilesExecutor(_cache.Executor):
             response = _requests.get(url)
         if not response.ok:
             raise IOError("Failed to download {}.  Got {}".format(url, response))
+        #test response content to prevent caching invalid images
+        try:
+            return _Image.open(_io.BytesIO(response.content))
+        except:
+            raise IOError("Received invalid tile from {}.  Got {}".format(url, response))
         return response.content
 
 

--- a/tilemapbase/tiles.py
+++ b/tilemapbase/tiles.py
@@ -192,7 +192,7 @@ class _TilesExecutor(_cache.Executor):
             raise IOError("Failed to download {}.  Got {}".format(url, response))
         #test response content to prevent caching invalid images
         try:
-            return _Image.open(_io.BytesIO(response.content))
+            _Image.open(_io.BytesIO(response.content))
         except:
             raise IOError("Received invalid tile from {}.  Got {}".format(url, response))
         return response.content


### PR DESCRIPTION
Test the response content to ensure it is a valid image prior to returning the "image" to the cache 